### PR TITLE
Allow editing H, S, L directly with text fields

### DIFF
--- a/dist/css/main.css
+++ b/dist/css/main.css
@@ -74,14 +74,36 @@ div.demo {
   margin-top: 20px;
 }
 
-#picker .hex {
-  width: 100px;
+
+#picker .hex, #picker .counter {
   padding-left: 5px;
   padding-right: 5px;
   color: #888;
   background: transparent;
-  border: 1px solid #555;
+  border-width: 1px;
+  border-style: solid;
   outline: none;
+}
+
+#picker .hex {
+  width: 100px;
+  border-color: #555;
+  margin-bottom: 2px; /* to align with the Lightness field to the left */
+}
+
+#picker .counter {
+  width: 61px;
+  border-color: #333;
+}
+
+/* hide spinners on <input type="number"> */
+input[type=number]::-webkit-outer-spin-button,
+input[type=number]::-webkit-inner-spin-button {
+    -webkit-appearance: none;
+    margin: 0;
+}
+input[type=number] {
+    -moz-appearance:textfield;
 }
 
 
@@ -100,10 +122,9 @@ table.sliders tr {
   height: 30px;
 }
 
-table.sliders td.counter {
-  padding-left: 15px;
+table.sliders td.counter-cell {
+  padding-left: 9px;
   width: 85px;
-  color: #777777;
 }
 
 table.sliders .swatch {

--- a/dist/index.html
+++ b/dist/index.html
@@ -57,7 +57,9 @@
                 <td>
                   <div class="slider-control control-hue"></div>
                 </td>
-                <td class="counter counter-hue">100.0</td>
+                <td class="counter-cell">
+                  <input type="number" class="counter counter-hue"/>
+                </td>
                 <td rowspan="3" style="width:100px">
                   <div class="swatch"></div>
                   <input class="hex"/>
@@ -68,14 +70,18 @@
                 <td>
                   <div class="slider-control control-saturation"></div>
                 </td>
-                <td class="counter counter-saturation">100.0</td>
+                <td class="counter-cell">
+                  <input type="number" class="counter counter-saturation"/>
+                </td>
               </tr>
               <tr>
                 <th>L</th>
                 <td>
                   <div class="slider-control control-lightness"></div>
                 </td>
-                <td class="counter counter-lightness">100.0</td>
+                <td class="counter-cell">
+                  <input type="number" class="counter counter-lightness"/>
+                </td>
               </tr>
             </table>
           </div>


### PR DESCRIPTION
Closes #3.

The counter and swatch area before:

![HSL numbers and swatch, before](https://cloud.githubusercontent.com/assets/79168/8296094/046cda40-191a-11e5-975b-ac961f1042b6.png)

And after:

![HSL numbers and swatch, after](https://cloud.githubusercontent.com/assets/79168/8296093/ffb2bd26-1919-11e5-8d5c-7b87ac913983.png)

See the individual commits for more details about the changes.