### PR TITLE
Display H, S, L with 1 decimal instead of 2

### DIFF
--- a/dist/css/main.css
+++ b/dist/css/main.css
@@ -92,7 +92,7 @@ div.demo {
 }
 
 #picker .counter {
-  width: 61px;
+  width: 53px;
   border-color: #333;
 }
 

--- a/src/main.coffee
+++ b/src/main.coffee
@@ -384,13 +384,13 @@ redrawSliderLightnessPosition = ->
   sliderLightness.redraw()
 
 updateSliderHueCounter = ->
-  d3.select('#picker .counter-hue').property 'value', H.toFixed 2
+  d3.select('#picker .counter-hue').property 'value', H.toFixed 1
 
 updateSliderSaturationCounter = ->
-  d3.select('#picker .counter-saturation').property 'value', S.toFixed 2
+  d3.select('#picker .counter-saturation').property 'value', S.toFixed 1
 
 updateSliderLightnessCounter = ->
-  d3.select('#picker .counter-lightness').property 'value', L.toFixed 2
+  d3.select('#picker .counter-lightness').property 'value', L.toFixed 1
 
 
 redrawSwatch = ->


### PR DESCRIPTION
![H, S, L with one decimal digit instead of two](https://cloud.githubusercontent.com/assets/79168/8304688/32aeaa12-1976-11e5-8af3-939a096aa4b6.png)

The sliders are too coarse for the hundredths digits to matter. For example, a one-pixel drag on Hue changes from it 181.59 to 182.65. The extra digits at the end just make the numbers look more confusing. 181.6 and 182.6 are precise enough.

With experiments, I determined that changing the value of a parameter by 0.1 never changes a R, G, or B byte by more than one. <strike>It also looks like all 24-bit colors can be represented with only tenths digits for each of the values – extra digits are not needed to uniquely specify a color.</strike>

If the user really wants two decimal points of precision, they can just type the extra digits in the H, S, and L fields.

Since the maximum width of the text is less now, I shrunk the text boxes towards the sliders, increasing the margin between the sliders and the swatch.