### PR TITLE
Move Swift from unfinished to finished with first release.

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -201,8 +201,21 @@
                 </td>
               </tr>
               <tr>
+                <th>
+                  <a href="https://github.com/husl-colors/husl-swift">
+                    Swift
+                  </a>
+                </th>
+                <td></td>
+                <td>
+                  <a href="https://github.com/husl-colors/husl-swift/releases/tag/v1.0.0">
+                    <img src="https://img.shields.io/cocoapods/v/HUSLSwift.svg"/>
+                  </a>
+                </td>
+              </tr>
+              <tr>
                 <td colspan="3">
-                  <strong>Unfinished ports: <a href="https://github.com/soulcutter/husler">Ruby</a>, <a href="https://github.com/husl-colors/husl/tree/master/ports/c">C</a>, <a href="https://github.com/husl-colors/husl/tree/master/ports/java">Java</a>, <a href="https://github.com/husl-colors/husl-swift">Swift</a>.</strong>
+                  <strong>Unfinished ports: <a href="https://github.com/soulcutter/husler">Ruby</a>, <a href="https://github.com/husl-colors/husl/tree/master/ports/c">C</a>, <a href="https://github.com/husl-colors/husl/tree/master/ports/java">Java</a>.</strong>
                 </td>
               </tr>
             </table>


### PR DESCRIPTION
The Swift project v1.0.0 is now published to Cocoapods, which I consider to be the "finishing step." There's still work to be done on HUSLP, but the current release is otherwise par with revision 4 for HUSL.