### PR TITLE
Allow typing hex codes with capital letters

### DIFF
--- a/src/main.coffee
+++ b/src/main.coffee
@@ -524,7 +524,7 @@ d3.select("#picker div.control-lightness").call(sliderLightness)
 
 
 stringIsValidHex = (string) ->
-  string.match(/#?[0-9a-f]{6}/)
+  string.match(/#?[0-9a-f]{6}/i)
 
 d3.select("#picker .hex").on 'input', ->
   if stringIsValidHex(@value)


### PR DESCRIPTION
Now, pasting “C0FFEE” into the hex field will work, not just “c0ffee”.

![“C0FFEE” is read from the hex field](https://cloud.githubusercontent.com/assets/79168/9366629/83a5c788-4686-11e5-91ed-53d28505cd79.png)