### PR TITLE
Fix red outline on Firefox due to input validation

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -58,7 +58,7 @@
                   <div class="slider-control control-hue"></div>
                 </td>
                 <td class="counter-cell">
-                  <input type="number" class="counter counter-hue"/>
+                  <input type="number" step="any" class="counter counter-hue"/>
                 </td>
                 <td rowspan="3" style="width:100px">
                   <div class="swatch"></div>
@@ -71,7 +71,7 @@
                   <div class="slider-control control-saturation"></div>
                 </td>
                 <td class="counter-cell">
-                  <input type="number" class="counter counter-saturation"/>
+                  <input type="number" step="any" class="counter counter-saturation"/>
                 </td>
               </tr>
               <tr>
@@ -80,7 +80,7 @@
                   <div class="slider-control control-lightness"></div>
                 </td>
                 <td class="counter-cell">
-                  <input type="number" class="counter counter-lightness"/>
+                  <input type="number" step="any" class="counter counter-lightness"/>
                 </td>
               </tr>
             </table>


### PR DESCRIPTION
The three H, S, L text fields in the color picker had red outlines in Firefox whenever they contained a non-integral value such as “57.8”, even when such values were automatically input when dragging the slider. This was because the `<input>`’s default step value of 1 also implied that only multiples of 1 were acceptable, and when the text fields failed validation, Firefox drew a red outline around them. The new step value of `any` means that any amount of precision is acceptable.

I didn’t completely disable the red outlines, which is possible with CSS, because they are still helpful if the user types a non-number into one of the fields.

### Before

![H, S, L fields where some fields have red outlines](https://cloud.githubusercontent.com/assets/79168/15382126/93802fe0-1d54-11e6-9a6d-de8c95bdb6a2.png)

### After

![H, S, L fields where no fields have red outlines](https://cloud.githubusercontent.com/assets/79168/15382128/97d49504-1d54-11e6-97fd-f52e36c763e6.png)

![H, S, L fields where the invalid input “abc” is outlined](https://cloud.githubusercontent.com/assets/79168/15382129/9a6b3b4c-1d54-11e6-83cb-b9d05d7d028e.png)