### PR TITLE
Add `pattern` attribute to hex color code <input>

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -62,7 +62,7 @@
                 </td>
                 <td rowspan="3" style="width:100px">
                   <div class="swatch"></div>
-                  <input class="hex"/>
+                  <input class="hex" pattern="#?[0-9a-fA-F]{6}"/>
                 </td>
               </tr>
               <tr>


### PR DESCRIPTION
In some browsers, this will give the user feedback when their input does not look like a hex color code. For example, Firefox highlights invalid fields in a red outline if they are blurred while invalid. This will help users correct errors faster.

![the field with a red outline because it contains “#000xyz”](https://cloud.githubusercontent.com/assets/79168/15382357/aa739248-1d57-11e6-912b-3c59a5ab6181.png)
