### PR TITLE
Added link to sass implementation

### DIFF
--- a/dist/index.html
+++ b/dist/index.html
@@ -246,6 +246,23 @@
                 </tr>
                 <tr>
                     <th>
+                        <a href="https://github.com/apexskier/husl-sass">
+                            Sass
+                        </a>
+                    </th>
+                    <td>
+                        <a href="http://travis-ci.org/apexskier/husl-sass">
+                            <img src="https://travis-ci.org/apexskier/husl-sass.svg?branch=master"/>
+                        </a>
+                    </td>
+                    <td>
+                        <a href="https://www.npmjs.com/package/husl-sass">
+                            <img src="https://img.shields.io/npm/v/husl-sass.svg"/>
+                        </a>
+                    </td>
+                </tr>
+                <tr>
+                    <th>
                         <a href="https://github.com/husl-colors/husl-objc">
                             <nobr>Objective-C</nobr>
                         </a>


### PR DESCRIPTION
I recently completed a pure sass port of husl and huslp (with testing) and think it would be useful to add it to the list on the website. 

https://github.com/apexskier/husl-sass

Let me know if there's anything missing or anything I can do to improve this.